### PR TITLE
Update building-from-source.md

### DIFF
--- a/installation-and-usage/installing-provenance/building-from-source.md
+++ b/installation-and-usage/installing-provenance/building-from-source.md
@@ -108,7 +108,7 @@ The Terminal app can be found in: _/Applications/Utilities_
 2. Install [RVM](https://rvm.io/):
 
    ```bash
-    \curl -sSL https://get.rvm.io | bash -s stable --ruby source ~/.rvm/scripts/rvm
+    \curl -sSL https://get.rvm.io | bash -s stable --ruby && source ~/.rvm/scripts/rvm
    ```
 
 #### First-time Setup


### PR DESCRIPTION
The command to install rvm is broken, two commands were merged together.

Running the command in the wiki verbatim looks like this:
```
bash-3.2$  \curl -sSL https://get.rvm.io | bash -s stable --ruby source ~/.rvm/scripts/rvm
curl: (6) Could not resolve host: Users
WARN: ...the preceeding error with code 6 occurred while fetching https://Users/api/v3/repos/athairus/.rvm/scripts/rvm//tags

ERROR: Exhausted all sources trying to fetch version 'latest' of RVM!

```

Splitting the `source` command from the `bash` command with a `&&` fixes this.