### PR TITLE
Feature: Add Razer Kishi Controller for iPhone.

### DIFF
--- a/info/controllers-and-controls/controllers/README.md
+++ b/info/controllers-and-controls/controllers/README.md
@@ -118,6 +118,7 @@ Standalone controllers are familiar to that of Playstation or Xbox. Recommended 
 
 | Controller | iPhone | iPad | aTV | Type | Profile | Rating |
 | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+| [Razer Kishi Controller for iPhone](https://www.amazon.com/Razer-Kishi-Controller-iPhone-Passthrough-mac/dp/B08FFPKRYW) | ● |  |  | MFi | Extended2+ | ●●●●◐ |
 | [GameVice: iPhone](https://www.amazon.com/Gamevice-Controller-Gamepad-iPhone-Certified-Compatible/dp/B077LZJ679/) Xʀ not supported | ● |  |  | MFi | Extended | ●●●●○ |
 | [GameVice: iPad Pro 12.9"](https://www.amazon.com/Gamevice-Controller-Gamepad-12-9-inch-Certified-Accessories/dp/B01MFCXJZD/) |  | ● |  | MFi | Extended | ●●●○○ |
 | [GameVice: iPad Mini](https://www.amazon.com/Controller-Gamepad-Gamevice-Certified-Accessories-Patented/dp/B01MR4VLJW/) |  | ● |  | MFi | Extended | ●●●◐○ |

--- a/info/controllers-and-controls/controllers/README.md
+++ b/info/controllers-and-controls/controllers/README.md
@@ -118,7 +118,7 @@ Standalone controllers are familiar to that of Playstation or Xbox. Recommended 
 
 | Controller | iPhone | iPad | aTV | Type | Profile | Rating |
 | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-| [Razer Kishi Controller for iPhone](https://www.amazon.com/Razer-Kishi-Controller-iPhone-Passthrough-mac/dp/B08FFPKRYW) | ● |  |  | MFi | Extended2+ | ●●●●◐ |
+| [Razer Kishi Controller for iPhone](https://www.amazon.com/Razer-Kishi-Controller-iPhone-Passthrough-mac/dp/B08FFPKRYW) | ● |  |  | MFi | Extended2+ | ●●●●● |
 | [GameVice: iPhone](https://www.amazon.com/Gamevice-Controller-Gamepad-iPhone-Certified-Compatible/dp/B077LZJ679/) Xʀ not supported | ● |  |  | MFi | Extended | ●●●●○ |
 | [GameVice: iPad Pro 12.9"](https://www.amazon.com/Gamevice-Controller-Gamepad-12-9-inch-Certified-Accessories/dp/B01MFCXJZD/) |  | ● |  | MFi | Extended | ●●●○○ |
 | [GameVice: iPad Mini](https://www.amazon.com/Controller-Gamepad-Gamevice-Certified-Accessories-Patented/dp/B01MR4VLJW/) |  | ● |  | MFi | Extended | ●●●◐○ |


### PR DESCRIPTION
## What does this PR do
Add Razer Kishi Controller for iPhone in Controller's list

### Adds
Add Razer Kishi Controller for iPhone in Controller's list

### Modifies
None

### Deletes
None

## Any background context you want to provide
On Friday I started testing the controller with my iPhone 11 Pro Max.

- We dont need to charge the controller, it consumes the battery from the iPhone using the lighting connector. But it's like the battery is not afected because I didn't noticed something different.

- Also, there is no bluetooth connection because it connects directly to the lighting connector. So unfortunately it can be used on an iPad and Apple TV, maybe next version.

Tested on Provenance on the next systems with some games:
- NES: Mario Bros 1, 2 and 3
- SNES: Donkey Kong Country, Super Mario All-Stars
- N64: Mario 64, Super Mario Kart, Mario Party

Also I tested on other emulators with some games:
- Moonlight Project: Skyrim, Fall Guys, Rocket League, Mortal Kombat 11, Street Fighter V, Horizon Zero Dawn, Tem tem
- Mame4iOS: different Street Fighters and old games
- PS Remote: Tested COD Black Ops Cold War Alpha, Spiderman
- Apple Arcade: Oceanhorn 2

## What are the relevant tickets

## Screenshots (if appropriate)

## Additional Comments
I pointed 4.5 before... but it's really like 5 points in this.
This collaboration between Gamevice and Razer was fantastic.
The buttons can be improved, BUT, damn, this is the best controller for the iPhone, in every aspect for gaming.

-----
[View rendered info/controllers-and-controls/controllers/README.md](https://github.com/richlira/wiki/blob/feature/razerkishi/info/controllers-and-controls/controllers/README.md)