### PR TITLE
feature: reference new build script in wiki

### DIFF
--- a/installation-and-usage/installing-provenance/building-from-source.md
+++ b/installation-and-usage/installing-provenance/building-from-source.md
@@ -116,8 +116,8 @@ The Terminal app can be found in: _/Applications/Utilities_
 4. Install and build the relevant Submodules, Setup & Launch
 
    ```bash
-    carthage bootstrap --platform iOS
-    carthage bootstrap --platform tvOS
+    ./carthage.sh bootstrap --platform iOS
+    ./carthage.sh bootstrap --platform tvOS
    ```
 
 5. Continue to [Build Source…](building-from-source.md#build-source) 


### PR DESCRIPTION
## What does this PR do
Updates the 'build from source' steps to use the new build script that supports Xcode 12

### Modifies
Changes the `carthage` command to instead use the build script

## Any background context you want to provide
This change was approved [here](https://github.com/Provenance-Emu/Provenance/pull/1441)


-----
[View rendered installation-and-usage/installing-provenance/building-from-source.md](https://github.com/Rapsac11/wiki/blob/Update-build-script/installation-and-usage/installing-provenance/building-from-source.md)