### PR TITLE
fix sideloading.md to remove cydia impactor

### DIFF
--- a/installation-and-usage/installing-provenance/sideloading.md
+++ b/installation-and-usage/installing-provenance/sideloading.md
@@ -14,7 +14,6 @@ Prebuilt .ipa releases can sideloaded onto your devices and must be re-signed us
 #### **Sideloading Options:**
 
 * ❇️  [**AltStore**](sideloading.md#altstore) · macOS/Window)
-* 🔨  [**Cydia Impactor** ](sideloading.md#cydia-impactor)· macOS/Windows
 * 🖋  [**iOS App Signer**](sideloading.md#ios-app-signer) · macOS + Xcode or Configurator
 * 🧪  [**AltDeploy**](sideloading.md#altdeploy) · macOS
 
@@ -41,39 +40,6 @@ Sideloading from 3rd party sources _**is not supported**_.
 {% endhint %}
 
 💢  If you get stuck, check out [Troubleshooting](sideloading.md#troubleshooting).
-
-## Cydia Impactor
-
-{% hint style="warning" %}
-Cydia Impactor hasn't been updated in a while and no longer works for _free_ Apple developers. Paid accounts should still work.
-{% endhint %}
-
-1. Download and launch [Cydia Impactor](http://www.cydiaimpactor.com/).
-2. Connect your device \(you may need to launch iTunes and choose `Trust…` when it pops up\).
-3. Select your device in Impactor.
-4. Drag & drop `.ipa` file onto Impactor.
-5. Enter your Apple ID.
-6. If _not_ using 2-Factor Authentication, enter your account password, otherwise…
-
-   1. _\(If you haven't yet\),_ login to your [Apple ID](https://appleid.apple.com/) online and `Generate` an App-Specific Password, under Security section \(and write it down somewhere for later use\).
-   2. Enter your App-Specific Password in Cydia Impactor, verbatim.
-
-  
-   ⚠️ If it fails to verify code signature, try resigning the .ipa with…
-
-   * Web: [appsigner.io](https://appsigner.io/) \(free devs only\)
-   * macOS \(only\): [iOS App Signer](https://dantheman827.github.io/ios-app-signer/)  —return to step 5.  🆔 Bundle ID: `com.[change-this].provenance`  Replace `[change-this]` with something unique like your username. 
-
-   🚸 If Impactor still fails, try [Option 2](sideloading.md#ios-app-signer) \(macOS only\).  
-
-7. On device: Go to `Settings` → `General` → `Profiles & Device Management`, tap on your certificate and then `Trust`
-8. _Done._  \(If using a free developer account, repeat from step 3 after it _**expires in 7 days**_\)
-
-{% hint style="info" %}
-Free Apple developer provisioning expires _every 7 days_, requiring reloading, but you will not lose any data.
-
-_Paid_ Apple Developer provisioning may only require re-signing once a year.
-{% endhint %}
 
 ## iOS App Signer
 


### PR DESCRIPTION
cydia impactor died due to changes earlier in the year,first for free accounts and now paid accounts,so changing the wiki to reflect that

## What does this PR do
cydia impactor died due to changes earlier in the year,first for free accounts and now paid accounts,so changing the wiki to reflect that

### Adds
nothing
### Modifies
sideloading.md
### Deletes
text in sideloading.md referencing cydia impactor
## Any background context you want to provide

## What are the relevant tickets

## Screenshots (if appropriate)

## Additional Comments


-----
[View rendered installation-and-usage/installing-provenance/sideloading.md](https://github.com/Carter1190/wiki/blob/patch-1/installation-and-usage/installing-provenance/sideloading.md)