### PR TITLE
Wrong identifier referenced in documentation

### DIFF
--- a/installation-and-usage/installing-provenance/building-from-source.md
+++ b/installation-and-usage/installing-provenance/building-from-source.md
@@ -114,11 +114,11 @@ At minimum, sign up as a free [Apple Developer](https://9to5mac.com/2016/03/27/h
 🛑 DO NOT enroll to join the full Developer Program or you will be locked into a _Pending_ payment state, unable to code-sign unless you pay or contact Apple to cancel the enrollment.
 {% endhint %}
 
-Copy `CodeSigning.xcconfig.sample` to `CodeSigning.xcconfig` and modify the file replacing `DEVELOPMENT_TEAM` with your Team ID and `PRODUCT_BUNDLE_PREFIX` with a bundle identifier that is registered to you.
+Copy `CodeSigning.xcconfig.sample` to `CodeSigning.xcconfig` and modify the file replacing `DEVELOPMENT_TEAM` with your Team ID and `ORG_IDENTIFIER` with a bundle identifier that is registered to you.
 
 If you have a paid Apple Developer account, you can find your Team ID at https://developer.apple.com/account/#/membership
 
-If you have a free Apple Developer account, you need to generate a new signing certificate. To do so, follow the steps in [iOS App Signer][3] to create a new Xcode project and generate a provisioning profile. After saving the project, open `project.pbxproj` inside your newly created `.xcproj` and look for `DEVELOPMENT_TEAM`. Copy this value to `CodeSigning.xcconfig` and your unique identifier to `PRODUCT_BUNDLE_PREFIX`.
+If you have a free Apple Developer account, you need to generate a new signing certificate. To do so, follow the steps in [iOS App Signer][3] to create a new Xcode project and generate a provisioning profile. After saving the project, open `project.pbxproj` inside your newly created `.xcproj` and look for `DEVELOPMENT_TEAM`. Copy this value to `CodeSigning.xcconfig` and your unique identifier to `ORG_IDENTIFIER`.
 
 Set `DEVELOPER_ACCOUNT_PAID = YES` if you used a paid Apple Developer account in order to automatically request the increased memory limit entitlement from Apple.
 


### PR DESCRIPTION
## What does this PR do

Fixes a faulty reference to an identifier in CodeSigning.xcconfig

### Adds

### Modifies

### Deletes

## Any background context you want to provide

## What are the relevant tickets

## Screenshots (if appropriate)

## Additional Comments
