### PR TITLE
Note to reopen project after fixing config file

### DIFF
--- a/installation-and-usage/installing-provenance/building-from-source.md
+++ b/installation-and-usage/installing-provenance/building-from-source.md
@@ -122,6 +122,8 @@ If you have a free Apple Developer account, you need to generate a new signing c
 
 Set `DEVELOPER_ACCOUNT_PAID = YES` if you used a paid Apple Developer account in order to automatically request the increased memory limit entitlement from Apple.
 
+After updating `CodeSigning.xcconfig`, re-open the project (remember to use `Provenance.xcworkspace` when opening the project).
+
 {% hint style="info" %}
  You can install a duplicate app for testing by using a different bundle ID than your previous/main install.
 {% endhint %}


### PR DESCRIPTION
## What does this PR do

Adds a note that after fixing the config file, you must reopen the project to pick up the changed values.

### Adds

### Modifies

### Deletes

## Any background context you want to provide

## What are the relevant tickets

## Screenshots (if appropriate)

## Additional Comments
